### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Open-Source-Uniandes/Aula-Finder/security/code-scanning/1](https://github.com/Open-Source-Uniandes/Aula-Finder/security/code-scanning/1)

Generally, the fix is to explicitly define a `permissions:` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For a typical CI workflow that just checks out code and runs npm commands without pushing changes or modifying PRs, `contents: read` is sufficient. This block can be set at the top level of the workflow (applies to all jobs) or per job.

For this workflow, the simplest non-breaking change is to add a top-level `permissions:` block directly under the `name: CI` line, setting `contents: read`. None of the existing steps require write access to the repository or other scopes. No additional imports, methods, or definitions are needed; this is purely a YAML configuration change within `.github/workflows/ci.yml`.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: CI`).  
All existing jobs and steps remain unchanged; they will now run with a read-only `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
